### PR TITLE
Set jOOQ version, removed JPA modelgen, removed unnecessary configruation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <java.version>21</java.version>
         <vaadin.version>25.0.0-beta2</vaadin.version>
+        <jooq.version>3.20.7</jooq.version>
         <archunit.version>1.4.1</archunit.version>
         <testcontainers-jooq-codegen-maven-plugin.version>0.0.4</testcontainers-jooq-codegen-maven-plugin.version>
         <spring-modulith.version>2.0.0-M3</spring-modulith.version>
@@ -148,19 +149,6 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.hibernate</groupId>
-                            <artifactId>hibernate-jpamodelgen</artifactId>
-                            <version>${hibernate.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>
                 <version>${vaadin.version}</version>
@@ -215,7 +203,6 @@
                                     </database>
                                     <target>
                                         <packageName>com.example.whereabouts.jooq</packageName>
-                                        <directory>target/generated-sources/jooq</directory>
                                     </target>
                                 </generator>
                             </jooq>


### PR DESCRIPTION
Spring Boot uses an old jOOQ version. This should also be set.

Removed the leftover from the JPA to jOOQ migration (jpa-modelgen)

Removed the directory configuration in the jOOQ generator configuration because this is the default.